### PR TITLE
Remove vscs-in-codespaces branches

### DIFF
--- a/.codespaces/init-ado-repo.sh
+++ b/.codespaces/init-ado-repo.sh
@@ -156,7 +156,7 @@ git pull origin $GIT_DEFAULT_BRANCH_NAME:$GIT_DEFAULT_BRANCH_NAME --force --no-t
 git checkout $GIT_DEFAULT_BRANCH_NAME &>/dev/null
 
 git branch -D $(git remote show github-origin | grep " *pushes to *" | awk '{print $1}' | xargs) &>/dev/null
-git remote remove github-origin $>/dev/null
+git remote remove github-origin &>/dev/null
 
 export ADO_PAT_BASE64=$(echo -n $ADO_PAT | base64)
 # replace env variable reference in the .npmrc

--- a/.codespaces/init-ado-repo.sh
+++ b/.codespaces/init-ado-repo.sh
@@ -2,8 +2,6 @@
 
 clear
 
-GITHUB_BRANCH="$(git branch)"
-
 cp -Ru . ~/ado-in-codespaces
 
 SCRIPT_DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" >/dev/null 2>&1 && pwd )"
@@ -157,9 +155,8 @@ git pull origin $GIT_DEFAULT_BRANCH_NAME:$GIT_DEFAULT_BRANCH_NAME --force --no-t
 
 git checkout $GIT_DEFAULT_BRANCH_NAME &>/dev/null
 
-# git remote remove github-origin
-# git branch -D main
-# git branch -D $GITHUB_BRANCH
+git branch -D $(git remote show github-origin | grep " *pushes to *" | awk '{print $1}' | xargs)
+git remote remove github-origin
 
 export ADO_PAT_BASE64=$(echo -n $ADO_PAT | base64)
 # replace env variable reference in the .npmrc

--- a/.codespaces/init-ado-repo.sh
+++ b/.codespaces/init-ado-repo.sh
@@ -151,12 +151,13 @@ echo -e $PALETTE_LIGHT_YELLOW"\n ⌬ Fetching the repo\n"$PALETTE_RESET
 git reset --hard
 git checkout main
 
-git branch --track github-main
-
 # clone the ADO repo
 git pull origin $GIT_DEFAULT_BRANCH_NAME:$GIT_DEFAULT_BRANCH_NAME --force --no-tags
 
 git checkout $GIT_DEFAULT_BRANCH_NAME &>/dev/null
+
+git branch -d main
+git branch -d codespaces-service
 
 export ADO_PAT_BASE64=$(echo -n $ADO_PAT | base64)
 # replace env variable reference in the .npmrc

--- a/.codespaces/init-ado-repo.sh
+++ b/.codespaces/init-ado-repo.sh
@@ -141,7 +141,6 @@ CLEAN_ADO_ORIGIN="${ADO_REPO_URL/https\:\/\//$EMPTY_STRING}"
 git remote remove github-origin &>/dev/null
 git remote rename origin github-origin &>/dev/null
 
-#git remote remove origin
 git remote add origin https://PAT:$ADO_PAT@$CLEAN_ADO_ORIGIN
 
 GIT_DEFAULT_BRANCH_NAME=$(git remote show origin | grep "HEAD branch\: " | sed 's/HEAD branch\: //g' | xargs)
@@ -156,8 +155,7 @@ git pull origin $GIT_DEFAULT_BRANCH_NAME:$GIT_DEFAULT_BRANCH_NAME --force --no-t
 
 git checkout $GIT_DEFAULT_BRANCH_NAME &>/dev/null
 
-git branch -d main
-git branch -d codespaces-service
+git remote remove github-origin
 
 export ADO_PAT_BASE64=$(echo -n $ADO_PAT | base64)
 # replace env variable reference in the .npmrc

--- a/.codespaces/init-ado-repo.sh
+++ b/.codespaces/init-ado-repo.sh
@@ -155,8 +155,8 @@ git pull origin $GIT_DEFAULT_BRANCH_NAME:$GIT_DEFAULT_BRANCH_NAME --force --no-t
 
 git checkout $GIT_DEFAULT_BRANCH_NAME &>/dev/null
 
-git branch -D $(git remote show github-origin | grep " *pushes to *" | awk '{print $1}' | xargs)
-git remote remove github-origin
+git branch -D $(git remote show github-origin | grep " *pushes to *" | awk '{print $1}' | xargs) &>/dev/null
+git remote remove github-origin $>/dev/null
 
 export ADO_PAT_BASE64=$(echo -n $ADO_PAT | base64)
 # replace env variable reference in the .npmrc

--- a/.codespaces/init-ado-repo.sh
+++ b/.codespaces/init-ado-repo.sh
@@ -157,9 +157,9 @@ git pull origin $GIT_DEFAULT_BRANCH_NAME:$GIT_DEFAULT_BRANCH_NAME --force --no-t
 
 git checkout $GIT_DEFAULT_BRANCH_NAME &>/dev/null
 
-git remote remove github-origin
-git branch -d main
-git branch -d $GITHUB_BRANCH
+# git remote remove github-origin
+# git branch -D main
+# git branch -D $GITHUB_BRANCH
 
 export ADO_PAT_BASE64=$(echo -n $ADO_PAT | base64)
 # replace env variable reference in the .npmrc

--- a/.codespaces/init-ado-repo.sh
+++ b/.codespaces/init-ado-repo.sh
@@ -2,6 +2,8 @@
 
 clear
 
+GITHUB_BRANCH="$(git branch)"
+
 cp -Ru . ~/ado-in-codespaces
 
 SCRIPT_DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" >/dev/null 2>&1 && pwd )"
@@ -156,6 +158,8 @@ git pull origin $GIT_DEFAULT_BRANCH_NAME:$GIT_DEFAULT_BRANCH_NAME --force --no-t
 git checkout $GIT_DEFAULT_BRANCH_NAME &>/dev/null
 
 git remote remove github-origin
+git branch -d main
+git branch -d $GITHUB_BRANCH
 
 export ADO_PAT_BASE64=$(echo -n $ADO_PAT | base64)
 # replace env variable reference in the .npmrc


### PR DESCRIPTION
This change deletes the local vscs-in-codespaces branches and remote so only the vsclk-core branches and remote show in the Codespace.

Fixes https://github.com/microsoft/vssaas-planning/issues/1889