### PR TITLE
Only exec bash in interactive

### DIFF
--- a/.codespaces/init-ado-repo.sh
+++ b/.codespaces/init-ado-repo.sh
@@ -279,4 +279,6 @@ if [ -f $USER_POST_CREATE_COMMAND_FILE ]; then
     . $USER_POST_CREATE_COMMAND_FILE
 fi
 
-exec bash
+if [ -z "$NONINTERACTIVE" ]; then
+    exec bash
+fi


### PR DESCRIPTION
Only exec bash in interactive so that all post create commands can run.